### PR TITLE
fix typo

### DIFF
--- a/plugins/output/flp.py
+++ b/plugins/output/flp.py
@@ -491,6 +491,6 @@ class output_cvpjs(plugins.base):
 							slotnum += 1
 							if slotnum == 10: break
 			else:
-				logger_output.warning('Mixer Channel "'+str(fx_num)+'" dosent exist.')
+				logger_output.warning('Mixer Channel "'+str(fx_num)+'" does not exist.')
 
 		flp_obj.make(output_file)


### PR DESCRIPTION
Found using `codespell -q 3 -L aadd,als,apoints,countin,gameboy,listin,nd,numer,ot,pitchin,startd,strat,testin,textin,ue`

Note: I hesitated to correct other typos because there seemed to be some hardcoded typos for a reason. I've left the codespelll invocation above up to the discretion of the dev who may feel an impulse to use and correct the rest of the typos if possible. 