### PR TITLE
Use UTF-8 encoding when reading reaper rpp file

### DIFF
--- a/objects/file_proj/proj_reaper.py
+++ b/objects/file_proj/proj_reaper.py
@@ -99,7 +99,7 @@ class rpp_song:
 		self.project = rpp_project.rpp_project()
 
 	def load_from_file(self, input_file):
-		bytestream = open(input_file, 'r')
+		bytestream = open(input_file, 'r', encoding="utf-8")
 		rpp_data = rpp.load(bytestream)
 		self.project.load(rpp_data)
 		return True

--- a/plugins/input/r_reaper.py
+++ b/plugins/input/r_reaper.py
@@ -135,12 +135,6 @@ class input_reaper(plugins.base):
 		from functions_plugin_ext import plugin_vst3
 		from functions_plugin_ext import plugin_clap
 
-		bytestream = open(input_file, 'r')
-		try:
-			rpp_data = rpp.load(bytestream)
-		except UnicodeDecodeError:
-			raise ProjectFileParserException('reaper: File is not text')
-
 		project_obj = proj_reaper.rpp_song()
 		if not project_obj.load_from_file(input_file): exit()
 


### PR DESCRIPTION
Reaper file is encoded in UTF-8. If a reaper file with non-English character is read without specifying `encoding=utf-8`, it will throw `UnicodeDecodeError`
#35 will be fixed