### PR TITLE
Expanded PPQ support for conversion

### DIFF
--- a/objects/notelist_splitter.py
+++ b/objects/notelist_splitter.py
@@ -44,18 +44,18 @@ class timesigblocks:
 
 	def timesig(self, endpos, ts, ppq, timesig_num, timesig_dem, startpos, mode):
 		if mode == 1: 
-			tcalc = float(timesig_num*timesig_dem)
+			tcalc = int(timesig_num*timesig_dem)
 			startd = startpos%(ppq*tcalc)
 		else: 
-			tcalc = float(timesig_num)
+			tcalc = int(timesig_num)
 			startd = startpos%ppq
 
-		self.timesigposs = [[0, float(tcalc*ppq)]]
+		self.timesigposs = [[0, int(tcalc*ppq)]]
 		for p, v in ts: 
 			if mode == 1: tscalc = timesig_num*timesig_dem
 			else: tscalc = timesig_num
 			self.timesigposs.append([startd+p, tscalc*ppq])
-		self.timesigposs += [[endpos, float(tcalc*ppq)]]
+		self.timesigposs += [[endpos, int(tcalc*ppq)]]
 		self.process()
 
 	def endsplit(self, endpos, splitdur, startpos):

--- a/objects/notelist_splitter.py
+++ b/objects/notelist_splitter.py
@@ -18,7 +18,7 @@ class timesigblocks:
 		mode = core.config_data.splitter_mode
 		detect_start = core.config_data.splitter_mode
 
-		ppq = float(convproj_obj.time_ppq)
+		ppq = int(convproj_obj.time_ppq)
 		songduration = convproj_obj.get_dur()+ppq
 
 		timesig_num, timesig_dem = convproj_obj.timesig

--- a/objects/notelist_splitter.py
+++ b/objects/notelist_splitter.py
@@ -18,7 +18,7 @@ class timesigblocks:
 		mode = core.config_data.splitter_mode
 		detect_start = core.config_data.splitter_mode
 
-		ppq = convproj_obj.time_ppq
+		ppq = float(convproj_obj.time_ppq)
 		songduration = convproj_obj.get_dur()+ppq
 
 		timesig_num, timesig_dem = convproj_obj.timesig
@@ -44,18 +44,18 @@ class timesigblocks:
 
 	def timesig(self, endpos, ts, ppq, timesig_num, timesig_dem, startpos, mode):
 		if mode == 1: 
-			tcalc = timesig_num*timesig_dem
+			tcalc = float(timesig_num*timesig_dem)
 			startd = startpos%(ppq*tcalc)
 		else: 
-			tcalc = timesig_num
+			tcalc = float(timesig_num)
 			startd = startpos%ppq
 
-		self.timesigposs = [[0, tcalc*ppq]]
+		self.timesigposs = [[0, float(tcalc*ppq)]]
 		for p, v in ts: 
 			if mode == 1: tscalc = timesig_num*timesig_dem
 			else: tscalc = timesig_num
 			self.timesigposs.append([startd+p, tscalc*ppq])
-		self.timesigposs += [[endpos, tcalc*ppq]]
+		self.timesigposs += [[endpos, float(tcalc*ppq)]]
 		self.process()
 
 	def endsplit(self, endpos, splitdur, startpos):


### PR DESCRIPTION
When attempting to convert MIDI as input, if the PPQ value was a large value such as 960, an error like the following would occur:

File "C:\ ... \DawVert\objects\notelist_splitter.py", line 71, in timesig
    self.timesigposs.append([startd+p, tscalc*ppq, new_numer])
                                                             ~~~^~~~
OverflowError: Python integer 960 out of bounds for uint8

This error was caused by an overflow in tscalc*ppq. To resolve this, I decided to explicitly declare the variable, which was probably treated as uint8, as an int.
If you experience any problems with this method, you don't need to merge it.