### PR TITLE
Fixed .rpp to be converted to .mid correctly, character code specification, variable type conversion, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ cython_debug/
 .cursorindexingignore
 
 __config/*
+__samples_extracted/*

--- a/functions/song_compat.py
+++ b/functions/song_compat.py
@@ -50,6 +50,11 @@ class song_compat:
 		self.process_part('unhybrid', unhybrid,					   convproj_obj, cvpj_type, in_dawinfo.track_hybrid, out_dawinfo.track_hybrid, out_type)
 		self.process_part('removelanes', removelanes,				 convproj_obj, cvpj_type, in_dawinfo.track_lanes, out_dawinfo, out_type)
 
+		if cvpj_type in ['r']:
+			if in_dawinfo.time_seconds and not out_dawinfo.time_seconds:
+				self.process_part('time_seconds', time_seconds,			   convproj_obj, cvpj_type, in_dawinfo.time_seconds, out_dawinfo.time_seconds, out_type)
+				if 'time_seconds' in self.finished_processes: self.currenttime = out_dawinfo.time_seconds
+
 		if self.currenttime == False:
 			self.process_part('autopl_addrem', autopl_addrem,		 convproj_obj, cvpj_type, in_dawinfo.auto_types, out_dawinfo.auto_types, out_type)
 			self.process_part('loops_remove', loops_remove,		   convproj_obj, cvpj_type, in_dawinfo.placement_loop, out_dawinfo.placement_loop, out_type)

--- a/functions/song_compat.py
+++ b/functions/song_compat.py
@@ -50,11 +50,6 @@ class song_compat:
 		self.process_part('unhybrid', unhybrid,					   convproj_obj, cvpj_type, in_dawinfo.track_hybrid, out_dawinfo.track_hybrid, out_type)
 		self.process_part('removelanes', removelanes,				 convproj_obj, cvpj_type, in_dawinfo.track_lanes, out_dawinfo, out_type)
 
-		if cvpj_type in ['r']:
-			if in_dawinfo.time_seconds and not out_dawinfo.time_seconds:
-				self.process_part('time_seconds', time_seconds,			   convproj_obj, cvpj_type, in_dawinfo.time_seconds, out_dawinfo.time_seconds, out_type)
-				if 'time_seconds' in self.finished_processes: self.currenttime = out_dawinfo.time_seconds
-
 		if self.currenttime == False:
 			self.process_part('autopl_addrem', autopl_addrem,		 convproj_obj, cvpj_type, in_dawinfo.auto_types, out_dawinfo.auto_types, out_type)
 			self.process_part('loops_remove', loops_remove,		   convproj_obj, cvpj_type, in_dawinfo.placement_loop, out_dawinfo.placement_loop, out_type)

--- a/objects/file_proj/proj_amped.py
+++ b/objects/file_proj/proj_amped.py
@@ -209,9 +209,9 @@ class amped_track:
 	def add_region(self, position, duration, offset, idnum):
 		amped_obj = amped_region(None, 'lime')
 		amped_obj.id = idnum
-		amped_obj.position = position/4
-		amped_obj.length = duration/4
-		amped_obj.offset = offset/4
+		amped_obj.position = float(position)/4
+		amped_obj.length = float(duration)/4
+		amped_obj.offset = float(offset)/4
 		self.regions.append(amped_obj)
 		return amped_obj
 

--- a/objects/file_proj/proj_reaper.py
+++ b/objects/file_proj/proj_reaper.py
@@ -99,8 +99,19 @@ class rpp_song:
 		self.project = rpp_project.rpp_project()
 
 	def load_from_file(self, input_file):
-		bytestream = open(input_file, 'r', encoding="utf-8")
-		rpp_data = rpp.load(bytestream)
+		try:
+			bytestream = open(input_file, 'r', encoding="utf-8")
+			rpp_data = rpp.load(bytestream)
+		except UnicodeDecodeError:
+			try:
+				bytestream.close()
+				bytestream = open(input_file, 'r', encoding="shift_jis")
+				rpp_data = rpp.load(bytestream)
+			except UnicodeDecodeError:
+				bytestream.close()
+				bytestream = open(input_file, 'r', encoding="cp1252")
+				rpp_data = rpp.load(bytestream)
+		
 		self.project.load(rpp_data)
 		return True
 

--- a/objects/notelist_splitter.py
+++ b/objects/notelist_splitter.py
@@ -22,6 +22,8 @@ class timesigblocks:
 		songduration = convproj_obj.get_dur()+ppq
 
 		timesig_num, timesig_dem = convproj_obj.timesig
+		timesig_num = int(timesig_num)
+		timesig_dem = int(timesig_dem)
 
 		if detect_start:
 			startpos = convproj_obj.loop_start if convproj_obj.loop_start else 0
@@ -40,9 +42,13 @@ class timesigblocks:
 				self.timesig(songduration, ts_parts, ppq, timesig_num, timesig_dem, outstart, mode)
 			else: 
 				pos, timesig = ts_parts[0]
-				self.timesig(songduration, ts_parts, ppq, timesig[0], timesig[1], outstart, mode)
+				self.timesig(songduration, ts_parts, ppq, int(timesig[0]), int(timesig[1]), outstart, mode)
 
 	def timesig(self, endpos, ts, ppq, timesig_num, timesig_dem, startpos, mode):
+		timesig_num = int(timesig_num)
+		timesig_dem = int(timesig_dem)
+		ppq = int(ppq)
+
 		if mode == 1: 
 			tcalc = int(timesig_num*timesig_dem)
 			startd = startpos%(ppq*tcalc)
@@ -54,7 +60,7 @@ class timesigblocks:
 		for p, v in ts: 
 			if mode == 1: tscalc = timesig_num*timesig_dem
 			else: tscalc = timesig_num
-			self.timesigposs.append([startd+p, tscalc*ppq])
+			self.timesigposs.append([startd+p, int(tscalc*ppq)])
 		self.timesigposs += [[endpos, int(tcalc*ppq)]]
 		self.process()
 

--- a/plugins/input/r_reaper.py
+++ b/plugins/input/r_reaper.py
@@ -44,23 +44,28 @@ class midi_notes():
 		midicmd, midich = data_bytes.splitbyte(int(tracksource_var[2],16))
 		midikey = int(tracksource_var[3],16)
 		midivel = int(tracksource_var[4],16)
-		if midicmd == 9: self.active_notes[midich][midikey].append([self.midipos, None, midivel])
-		if midicmd == 8: self.active_notes[midich][midikey][-1][1] = self.midipos
+		
+		if midicmd == 9 and midivel > 0: 
+			self.active_notes[midich][midikey].append([self.midipos, None, midivel])
+		
+		if midicmd == 8 or (midicmd == 9 and midivel == 0):
+			if len(self.active_notes[midich][midikey]) > 0:
+				self.active_notes[midich][midikey][-1][1] = self.midipos
 
-	def do_output(self, cvpj_notelist, ppq):
+	def do_output(self, cvpj_notelist, ppq, target_ppq=1):
 		for c_mid_ch in range(16):
 			for c_mid_key in range(127):
 				if self.active_notes[c_mid_ch][c_mid_key] != []:
 					for notedurpos in self.active_notes[c_mid_ch][c_mid_key]:
 						if notedurpos[1] != None:
 							cvpj_notelist.add_r(
-								notedurpos[0]/(ppq), 
-								(notedurpos[1]-notedurpos[0])/(ppq), 
+								(notedurpos[0]/(ppq))*target_ppq, 
+								((notedurpos[1]-notedurpos[0])/(ppq))*target_ppq, 
 								c_mid_key-60, 
 								notedurpos[2]/127, 
 								{'channel': c_mid_ch}
 								)
-							cvpj_notelist.time_ppq = 1
+							cvpj_notelist.time_ppq = target_ppq
 							cvpj_notelist.time_float = True
 		cvpj_notelist.sort()
 		#print(cvpj_notelist.data[:])
@@ -358,21 +363,29 @@ class input_reaper(plugins.base):
 								if insource.type in ['MP3','FLAC','VORBIS','WAVE','WAVPACK']:
 									cvpj_placement_type = 'audio'
 									cvpj_audio_file = insource.file.get()
+								if insource.type in ['MIDI']:
+									midi_ppq = insource.hasdata['ppq']
+									for note in insource.notes: midi_notes_out.do_note(note)
 
 				cvpj_offset_bpm = ((cvpj_offset)*8)*tempomul
 				cvpj_end_bpm = ((midi_notes_out.midipos/midi_ppq)*4)
 
 				if cvpj_placement_type == 'notes': 
 					placement_obj = track_obj.placements.add_notes()
+
+
 					if cvpj_name: placement_obj.visual.name = cvpj_name
 					if cvpj_color: placement_obj.visual.color.set_float(cvpj_color)
 					placement_obj.time.position_real = cvpj_position
 					placement_obj.time.duration_real = cvpj_duration
 
-					placement_obj.time.cut_type = 'loop'
-					placement_obj.time.set_loop_data(cvpj_offset_bpm, 0, cvpj_end_bpm)
+					# placement_obj.time.cut_type = 'loop'
+					# placement_obj.time.set_loop_data(cvpj_offset_bpm, 0, cvpj_end_bpm)
 
-					midi_notes_out.do_output(placement_obj.notelist, midi_ppq)
+					midi_notes_out.do_output(placement_obj.notelist, midi_ppq, 4)
+
+					cvpj_duration_bpm = ((cvpj_duration)*8)*tempomul
+					placement_obj.notelist.edit_trimmove(cvpj_offset_bpm, cvpj_offset_bpm + cvpj_duration_bpm)
 
 				if cvpj_placement_type == 'audio': 
 					placement_obj = track_obj.placements.add_audio()

--- a/plugins/output/amped_studio.py
+++ b/plugins/output/amped_studio.py
@@ -19,7 +19,7 @@ def convauto(autopoints, param_obj):
 	ampedauto = []
 	for autopoint in autopoints:
 		value = xtramath.between_to_one(param_obj.min, param_obj.max, autopoint.value)
-		ampedauto.append({"pos": autopoint.pos/4, "value": value})
+		ampedauto.append({"pos": float(autopoint.pos)/4, "value": float(value)})
 	return ampedauto
 
 def createclip(audiopl_obj, audio_id):
@@ -28,11 +28,11 @@ def createclip(audiopl_obj, audio_id):
 	amped_audclip.contentGuid.is_custom = True
 	amped_audclip.contentGuid.id = audio_id[audiopl_obj.sample.sampleref] if audiopl_obj.sample.sampleref in audio_id else ''
 	amped_audclip.position = 0
-	amped_audclip.gain = audiopl_obj.sample.vol
-	amped_audclip.length = audiopl_obj.time.duration*4
+	amped_audclip.gain = float(audiopl_obj.sample.vol)
+	amped_audclip.length = float(audiopl_obj.time.duration)*4
 	amped_audclip.offset = 0
-	amped_audclip.stretch = audiopl_obj.sample.stretch.calc_real_size
-	amped_audclip.pitchShift = audiopl_obj.sample.pitch
+	amped_audclip.stretch = float(audiopl_obj.sample.stretch.calc_real_size)
+	amped_audclip.pitchShift = float(audiopl_obj.sample.pitch)
 	return amped_audclip
 
 def do_idparams(amped_track, convproj_obj, plugin_obj, pluginid, amped_device, amped_auto):
@@ -49,7 +49,7 @@ def do_idparams(amped_track, convproj_obj, plugin_obj, pluginid, amped_device, a
 				autospec = {"type": "numeric", "min": param_obj.min, "max": param_obj.max, "curve": 0, "step": 0}
 				amped_auto = amped_track.add_auto(paramid, True, amped_device.id, convauto(ap_d.nopl_points, param_obj), autospec)
 
-		amped_device.add_param(paramnum, ampedpid, param_obj.value)
+		amped_device.add_param(paramnum, ampedpid, float(param_obj.value))
 	return paramout
 
 def amped_parse_effects(amped_track, convproj_obj, fxchain_audio, amped_auto):
@@ -154,7 +154,7 @@ class output_amped(plugins.base):
 
 		amped_obj.createdWith = "DawVert"
 		amped_obj.settings = {"deviceDelayCompensation": True}
-		amped_obj.masterTrack.volume = convproj_obj.track_master.params.get('vol', 1).value
+		amped_obj.masterTrack.volume = float(convproj_obj.track_master.params.get('vol', 1).value)
 		#amped_obj.masterTrack.devices = amped_parse_effects(None, convproj_obj, convproj_obj.track_master.plugslots.slots_audio, None)
 
 		audio_id = {}
@@ -172,8 +172,8 @@ class output_amped(plugins.base):
 			amped_track = proj_amped.amped_track(None)
 			amped_track.id = counter_id.get()
 			amped_track.name = track_obj.visual.name if track_obj.visual.name else ''
-			amped_track.pan = track_obj.params.get('pan', 0).value
-			amped_track.volume = track_obj.params.get('vol', 1.0).value
+			amped_track.pan = float(track_obj.params.get('pan', 0).value)
+			amped_track.volume = float(track_obj.params.get('vol', 1.0).value)
 			amped_track.mute = not track_obj.params.get('on', True).value
 			amped_track.solo = bool(track_obj.params.get('solo', False).value)
 
@@ -193,7 +193,7 @@ class output_amped(plugins.base):
 					wamPreset['bank'] = ''
 					wamPreset['bankName'] = ''
 					wamPreset['patchIndex'] = 0
-					wamPreset['data'] = [plugin_obj.params.get('obxd_'+str(x), 0).value for x in range(71)]
+					wamPreset['data'] = [float(plugin_obj.params.get('obxd_'+str(x), 0).value) for x in range(71)]
 					amped_device.data['wamClassName'] = 'OBXD'
 					amped_device.data['wamPreset'] = json.dumps(wamPreset)
 					amped_device.bypass = False
@@ -205,7 +205,7 @@ class output_amped(plugins.base):
 					wamPreset['bank'] = ''
 					wamPreset['bankName'] = ''
 					wamPreset['patchIndex'] = 0
-					wamPreset['data'] = [plugin_obj.params.get('augur_'+str(x), 0).value for x in range(183)]
+					wamPreset['data'] = [float(plugin_obj.params.get('augur_'+str(x), 0).value) for x in range(183)]
 					amped_device.data['wamClassName'] = 'AUGUR'
 					amped_device.data['wamPreset'] = json.dumps(wamPreset)
 					amped_device.bypass = False
@@ -246,7 +246,7 @@ class output_amped(plugins.base):
 					for eur_value_name in europa_vals:
 						eur_value_type, cvpj_val_name = europa_vals[eur_value_name]
 						if eur_value_type == 'number':
-							eur_value_value = plugin_obj.params.get(cvpj_val_name, 0).value
+							eur_value_value = float(plugin_obj.params.get(cvpj_val_name, 0).value)
 						else:
 							eur_value_value = plugin_obj.datavals.get(cvpj_val_name, '')
 							if eur_value_name in ['Curve1','Curve2','Curve3','Curve4','Curve']: 
@@ -299,7 +299,7 @@ class output_amped(plugins.base):
 								"position": float(t_pos)/4, 
 								"length": float(t_dur)/4, 
 								"key": int(t_key+60),
-								"velocity": t_vol*100, 
+								"velocity": float(t_vol*100), 
 								"channel": 0
 								})
 
@@ -308,7 +308,7 @@ class output_amped(plugins.base):
 				if audiopl_obj.time.cut_type == 'cut': amped_offset = audiopl_obj.time.cut_start
 				amped_region = amped_track.add_region(audiopl_obj.time.position, audiopl_obj.time.duration, amped_offset, counter_id.get())
 				amped_audclip = createclip(audiopl_obj, audio_id)
-				amped_audclip.fadeIn = audiopl_obj.fade_in.get_dur_beat(amped_obj.tempo)
+				amped_audclip.fadeIn = float(audiopl_obj.fade_in.get_dur_beat(amped_obj.tempo))
 				amped_region.clips = [amped_audclip]
 
 			for nestedaudiopl_obj in track_obj.placements.pl_audio_nested:
@@ -318,7 +318,7 @@ class output_amped(plugins.base):
 						amped_audclip = createclip(insideaudiopl_obj, audio_id)
 						amped_audclip.position = insideaudiopl_obj.time.position/4
 						amped_audclip.length = insideaudiopl_obj.time.duration/4
-						amped_audclip.fadeIn = insideaudiopl_obj.fade_in.get_dur_beat(amped_obj.tempo)
+						amped_audclip.fadeIn = float(insideaudiopl_obj.fade_in.get_dur_beat(amped_obj.tempo))
 						if insideaudiopl_obj.time.cut_type == 'cut': 
 							amped_audclip.offset = (insideaudiopl_obj.time.cut_start/4)
 						amped_region.clips.append(amped_audclip)

--- a/plugins/output/midi.py
+++ b/plugins/output/midi.py
@@ -37,7 +37,7 @@ class output_cvpj_f(plugins.base):
 
 		convproj_obj.change_timings(384, False)
 		
-		midiobj = mido.MidiFile()
+		midiobj = mido.MidiFile(charset='utf-8')
 		midiobj.ticks_per_beat = convproj_obj.time_ppq
 		multi_miditrack = []
 


### PR DESCRIPTION
- Fixed an issue where notes were converted shorter than intended when converting REAPER project files to MIDI.
- Added "__samples_extracted/*" to .gitignore.
- Explicitly set the type to float to ensure Amped Studio project files are converted correctly.
- Fixed garbled characters when converting to MIDI files by setting "charset='utf-8'".

If you experience any problems with this method, you don't need to merge it.